### PR TITLE
First time grant failure

### DIFF
--- a/scripts/keri/cf/demo-witness-oobis.json
+++ b/scripts/keri/cf/demo-witness-oobis.json
@@ -6,8 +6,8 @@
   },
   "iurls": [
     "http://127.0.0.1:5642/oobi/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha/controller?name=Wan&tag=witness",
-    "http://127.0.0.1:5643/oobi/BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM/controller?name=Wes&tag=witness",
-    "http://127.0.0.1:5644/oobi/BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX/controller?name=Wil&tag=witness",
+    "http://127.0.0.1:5643/oobi/BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM/controller?name=Wil&tag=witness",
+    "http://127.0.0.1:5644/oobi/BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX/controller?name=Wes&tag=witness",
     "http://127.0.0.1:5645/oobi/BM35JN8XeJSEfpxopjn5jr7tAHCE5749f0OobhMLCorE/controller?name=Wit&tag=witness",
     "http://127.0.0.1:5646/oobi/BIj15u5V11bkbtAxMA7gcNJZcax-7TgaBMLsQnMHpYHP/controller?name=Wub&tag=witness",
     "http://127.0.0.1:5647/oobi/BF2rZTW79z4IXocYRQnjjsOuvFUQv-ptCf8Yltd7PfsM/controller?name=Wyz&tag=witness"

--- a/scripts/keria.json
+++ b/scripts/keria.json
@@ -1,0 +1,16 @@
+{
+  "dt": "2025-01-03T16:08:30.123456+00:00",
+  "keria": {
+    "dt": "2025-01-03T16:08:30.123457+00:00",
+    "curls": ["http://127.0.0.1:3902/"]
+  },
+  "iurls": [
+    "http://127.0.0.1:5642/oobi/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha/controller?name=Wan&tag=witness",
+    "http://127.0.0.1:5643/oobi/BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM/controller?name=Wil&tag=witness",
+    "http://127.0.0.1:5644/oobi/BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX/controller?name=Wes&tag=witness"
+  ],
+  "tocks": {
+    "initer": 0.0,
+    "escrower": 1.0
+  }
+}

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
     python_requires='>=3.12.2',
     install_requires=[
         'hio==0.6.14',
-        'keri==1.2.6',
+        'keri==1.2.7',
         'mnemonic==0.21',
         'multicommand==1.0.0',
         'falcon==4.0.2',

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
     python_requires='>=3.12.2',
     install_requires=[
         'hio==0.6.14',
-        'keri==1.2.4',
+        'keri==1.2.6',
         'mnemonic==0.21',
         'multicommand==1.0.0',
         'falcon==4.0.2',

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ setup(
         'http_sfv==0.9.9',
         'dataclasses_json==0.6.7',
         'apispec==6.8.1',
+        'deprecation==2.1.0',
     ],
     extras_require={
         'test': ['pytest', 'coverage'],

--- a/src/keria/__init__.py
+++ b/src/keria/__init__.py
@@ -5,3 +5,29 @@ main package
 
 __version__ = '0.2.0-rc2'  # also change in setup.py
 
+import logging
+from hio.help import ogling
+from .app.logs import TruncatedFormatter
+
+log_name = 'keria'  # name of this project that shows up in log messages
+log_format_str = f'%(asctime)s [{log_name}] %(levelname)-8s %(module)s.%(funcName)s-%(lineno)s %(message)s'
+
+ogler = ogling.initOgler(prefix=log_name, syslogged=False)
+ogler.level = logging.INFO
+
+formatter = TruncatedFormatter(log_format_str)
+formatter.default_msec_format = None
+logHandler = logging.StreamHandler()
+logHandler.setFormatter(formatter)
+ogler.baseFormatter = formatter
+ogler.baseConsoleHandler = logHandler
+ogler.baseConsoleHandler.setFormatter(formatter)
+ogler.reopen(name=log_name, temp=True, clear=True)
+
+def set_log_level(loglevel, logger):
+    """Set the log level for the logger."""
+    ogler.level = logging.getLevelName(loglevel.upper())
+    logger.setLevel(ogler.level)
+
+
+

--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -826,7 +826,7 @@ class ParserDoer(doing.Doer):
         self.tock = tock
         super(ParserDoer, self).__init__(tock=self.tock)
 
-    def recur(self, tyme=None):
+    def recur(self, tyme=None, tock=0.0, **opts):
         """
         Continually processes messages on the incoming message stream (ims).
         Inner parsator yields continually when the stream is empty, making this good for long-running
@@ -850,7 +850,7 @@ class Witnesser(doing.Doer):
         self.tock = tock
         super(Witnesser, self).__init__(tock=self.tock)
 
-    def recur(self, tyme=None):
+    def recur(self, tyme=None, tock=0.0, **opts):
         while True:
             if self.witners:
                 msg = self.witners.popleft()
@@ -876,7 +876,7 @@ class Delegator(doing.Doer):
         self.tock = tock
         super(Delegator, self).__init__(tock=self.tock)
 
-    def recur(self, tyme=None):
+    def recur(self, tyme=None, tock=0.0, **opts):
         if self.anchors:
             msg = self.anchors.popleft()
             sn = msg["sn"] if "sn" in msg else None
@@ -1032,7 +1032,7 @@ class Admitter(doing.Doer):
         self.tock = tock
         super(Admitter, self).__init__(tock=self.tock)
 
-    def recur(self, tyme):
+    def recur(self, tyme, tock=0.0, **opts):
         if self.admits:
             msg = self.admits.popleft()
             said = msg['said']
@@ -1076,7 +1076,7 @@ class SeekerDoer(doing.Doer):
         self.tock = tock
         super(SeekerDoer, self).__init__(tock=self.tock)
 
-    def recur(self, tyme=None):
+    def recur(self, tyme=None, tock=0.0, **opts):
         if self.cues:
             cue = self.cues.popleft()
             if cue["kin"] == "saved":
@@ -1100,7 +1100,7 @@ class ExchangeCueDoer(doing.Doer):
         self.tock = tock
         super(ExchangeCueDoer, self).__init__(tock=self.tock)
 
-    def recur(self, tyme=None):
+    def recur(self, tyme=None, tock=0.0, **opts):
         if self.cues:
             cue = self.cues.popleft()
             if cue["kin"] == "saved":
@@ -1138,7 +1138,7 @@ class Initer(doing.Doer):
             logger.info(agent_label)
         return True
 
-    def recur(self, tyme):
+    def recur(self, tyme, tock=0.0, **opts):
         return self.print_agent()
 
 
@@ -1152,7 +1152,7 @@ class GroupRequester(doing.Doer):
         self.tock = tock
         super(GroupRequester, self).__init__(tock=self.tock)
 
-    def recur(self, tyme):
+    def recur(self, tyme, tock=0.0, **opts):
         """ Checks cue for group processing requests and handles any with Counselor """
         if self.groups:
             msg = self.groups.popleft()
@@ -1231,7 +1231,7 @@ class Escrower(doing.Doer):
 
         super(Escrower, self).__init__(tock=self.tock)
 
-    def recur(self, tyme):
+    def recur(self, tyme, tock=0.0, **opts):
         """ Process all escrows once per loop. """
         self.kvy.processEscrows()
         self.kvy.processEscrowDelegables()
@@ -1260,7 +1260,7 @@ class Releaser(doing.Doer):
 
         super(Releaser, self).__init__(tock=self.tock)
 
-    def recur(self, tyme=None):
+    def recur(self, tyme=None, tock=0.0, **opts):
         while True:
             idle = []
             for caid in self.agents:

--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -677,12 +677,12 @@ class ExchangeSender(doing.DoDoer):
             rec = msg["rec"]
             topic = msg['topic']
             hab = self.hby.habs[pre]
-            logger.debug("[%s | %s...%s]: Current Message Body= %s", hab.name, hab.pre[:4], hab.pre[-4:], msg);
+            logger.debug("[%s | %s]: Current Message Body= %s", hab.name, hab.pre, msg);
             if self.exc.lead(hab, said=said):
                 atc = exchanging.serializeMessage(self.hby, said)
                 del atc[:serder.size]
                 for recp in rec:
-                    logger.debug("[%s | %s...%s]: Sending on topic %s to recipient %s from %s", hab.name, hab.pre[:4], hab.pre[-4:], topic, recp, pre)
+                    logger.debug("[%s | %s]: Sending on topic %s to recipient %s from %s", hab.name, hab.pre, topic, recp, pre)
                     postman = forwarding.StreamPoster(hby=self.hby, hab=self.agentHab, recp=recp, topic=topic)
                     try:
                         postman.send(serder=serder,

--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -53,6 +53,11 @@ from ..core.authing import Authenticater
 from ..core.keeping import RemoteManager
 from ..db import basing
 
+formatter = logging.Formatter('keria: %(asctime)s - %(levelname)s - %(message)s')
+logHandler = logging.StreamHandler()
+logHandler.setFormatter(formatter)
+ogler.baseFormatter = formatter
+ogler.baseConsoleHandler = logHandler
 logger = ogler.getLogger()
 
 @dataclass
@@ -120,11 +125,11 @@ class KERIAServerConfig:
 
 def runAgency(config: KERIAServerConfig):
     """Runs a KERIA Agency with the given Doers by calling Doist.do(). Useful for testing."""
-    help.ogler.level = logging.getLevelName(config.logLevel)
-    logger.setLevel(help.ogler.level)
+    ogler.level = logging.getLevelName(config.logLevel)
+    logger.setLevel(ogler.level)
     if config.logFile is not None:
-        help.ogler.headDirPath = config.logFile
-        help.ogler.reopen(name=config.name, temp=False, clear=True)
+        ogler.headDirPath = config.logFile
+        ogler.reopen(name=config.name, temp=False, clear=True)
 
     logger.info("Starting Agent for %s listening: admin/%s, http/%s, boot/%s",
                 config.name, config.adminPort, config.httpPort, config.bootPort)
@@ -657,10 +662,12 @@ class ExchangeSender(doing.DoDoer):
             rec = msg["rec"]
             topic = msg['topic']
             hab = self.hby.habs[pre]
+            logger.debug("[%s | %s...%s]: Current Message Body= %s", hab.name, hab.pre[:4], hab.pre[-4:], msg);
             if self.exc.lead(hab, said=said):
                 atc = exchanging.serializeMessage(self.hby, said)
                 del atc[:serder.size]
                 for recp in rec:
+                    logger.debug("[%s | %s...%s]: Sending on topic %s to recipient %s from %s", hab.name, hab.pre[:4], hab.pre[-4:], topic, recp, pre)
                     postman = forwarding.StreamPoster(hby=self.hby, hab=self.agentHab, recp=recp, topic=topic)
                     try:
                         postman.send(serder=serder,

--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -158,7 +158,7 @@ def getAgency(doers):
     for doer in doers:
         if isinstance(doer, Agency):
             return doer
-        return None
+    return None
 
 
 class Agency(doing.DoDoer):

--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -827,6 +827,11 @@ class ParserDoer(doing.Doer):
         super(ParserDoer, self).__init__(tock=self.tock)
 
     def recur(self, tyme=None):
+        """
+        Continually processes messages on the incoming message stream (ims).
+        Inner parsator yields continually when the stream is empty, making this good for long-running
+        servers.
+        """
         if self.parser.ims:
             logger.info("Agent %s received:\n%s\n...\n", self.kvy, self.parser.ims[:1024])
         done = yield from self.parser.parsator()  # process messages continuously

--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -19,10 +19,10 @@ import falcon
 import lmdb
 from falcon import media
 from hio.base import doing, Doer
-from hio.core import http, tcp
+from hio.core import http
 from hio.help import decking
 
-from keri import core, kering, help
+from keri import core, kering
 from keri.app.notifying import Notifier
 from keri.app.storing import Mailboxer
 
@@ -47,6 +47,8 @@ from keri.app import challenging
 from . import aiding, notifying, indirecting, credentialing, ipexing, delegating
 from . import grouping as keriagrouping
 from .serving import GracefulShutdownDoer
+from .. import log_name, ogler, set_log_level
+from ..core.httping import falconApp, createHttpServer
 from ..peer import exchanging as keriaexchanging
 from .specing import AgentSpecResource
 from ..core import authing, longrunning, httping
@@ -54,27 +56,7 @@ from ..core.authing import Authenticater
 from ..core.keeping import RemoteManager
 from ..db import basing
 
-class TruncatedFormatter(logging.Formatter):
-    """Formats log records with shorter module and function names and a right justified line number for readability."""
-    def __init__(self, fmt=None, datefmt=None, style='%'):
-        super().__init__(fmt, datefmt, style)
-
-    def format(self, record):
-        # Truncate module and funcName to first 'chars' characters
-        mod_chars = 10 # number of spaces to truncate to
-        fn_chars = 14 # number of spaces to truncate to
-        record.module = (record.module[:mod_chars] + ' ' * mod_chars)[:mod_chars]
-        record.funcName = (record.funcName[:fn_chars] + ' ' * fn_chars)[:fn_chars]
-        record.lineno = str(record.lineno).rjust(5)  # Ensure line number is right-aligned
-        return super().format(record)
-
-formatter = TruncatedFormatter('%(asctime)s [keria] %(levelname)-8s %(module)s.%(funcName)s-%(lineno)s %(message)s')
-formatter.default_msec_format = None
-logHandler = logging.StreamHandler()
-logHandler.setFormatter(formatter)
-ogler.baseFormatter = formatter
-ogler.baseConsoleHandler = logHandler
-logger = ogler.getLogger()
+logger = ogler.getLogger(log_name)
 
 @dataclass
 class KERIAServerConfig:
@@ -141,8 +123,7 @@ class KERIAServerConfig:
 
 def runAgency(config: KERIAServerConfig):
     """Runs a KERIA Agency with the given Doers by calling Doist.do(). Useful for testing."""
-    ogler.level = logging.getLevelName(config.logLevel)
-    logger.setLevel(ogler.level)
+    set_log_level(config.logLevel, logger)
     if config.logFile is not None:
         ogler.headDirPath = config.logFile
         ogler.reopen(name="keria", temp=False, clear=True)
@@ -807,6 +788,107 @@ class Agent(doing.DoDoer):
             except lmdb.Error as ex:  # Sometimes LMDB will throw an error if the DB is already closed
                 logger.error(f"Error closing database {db.__class__.__name__} for agent {self.caid}: {ex}")
         logger.info(f"Agent {self.caid} shut down")
+
+def createBootServerDoer(config: KERIAServerConfig, agency: Agency):
+    """Create the Agent boot HTTP server and the Doer to run it. Returns only the Doer."""
+    bootApp = falconApp()
+
+    bootEnd = BootEnd(agency, username=config.bootUsername, password=config.bootPassword)
+    bootApp.add_route("/boot", bootEnd)
+    bootApp.add_route("/health", HealthEnd())
+
+    bootServer = createHttpServer(config.bootPort, bootApp, config.keyPath, config.certPath, config.caFilePath)
+    if not bootServer.reopen():
+        raise RuntimeError(f"Cannot create boot HTTP server on port {config.bootPort}")
+    return http.ServerDoer(server=bootServer)
+
+def createAdminServerDoer(config: KERIAServerConfig, agency: Agency):
+    """
+    Create the Admin HTTP server and the Doer to run it.
+    Returns the Doer and the Falcon app so the HTTP app can use it for OpenAPI docs.
+    """
+    # Create Authenticater for verifying signatures on all requests
+    authn = Authenticater(agency=agency)
+
+    adminApp = falconApp()
+    if config.cors:
+        adminApp.add_middleware(middleware=httping.HandleCORS())
+    adminApp.add_middleware(authing.SignatureValidationComponent(agency=agency, authn=authn, allowed=["/agent"]))
+    adminApp.req_options.media_handlers.update(media.Handlers())
+    adminApp.resp_options.media_handlers.update(media.Handlers())
+
+    loadEnds(app=adminApp)
+    aidEnd = aiding.loadEnds(app=adminApp, agency=agency, authn=authn)
+    credentialing.loadEnds(app=adminApp, identifierResource=aidEnd)
+    delegating.loadEnds(app=adminApp, identifierResource=aidEnd)
+    notifying.loadEnds(app=adminApp)
+    keriagrouping.loadEnds(app=adminApp)
+
+    keriaexchanging.loadEnds(app=adminApp)
+    ipexing.loadEnds(app=adminApp)
+
+    adminServer = createHttpServer(config.adminPort, adminApp, config.keyPath, config.certPath, config.caFilePath)
+    if not adminServer.reopen():
+        raise RuntimeError(f"cannot create admin HTTP server on port {config.adminPort}")
+    return adminApp, http.ServerDoer(server=adminServer)
+
+def createHttpServerDoer(config: KERIAServerConfig, agency: Agency, adminApp: falcon.App):
+    """Create the main HTTP server and the Doer to run it. Returns only the Doer."""
+    happ = falconApp()
+    happ.req_options.media_handlers.update(media.Handlers())
+    happ.resp_options.media_handlers.update(media.Handlers())
+
+    ending.loadEnds(agency=agency, app=happ)
+    indirecting.loadEnds(agency=agency, app=happ)
+
+    swagsink = http.serving.StaticSink(staticDirPath="./static")
+    happ.add_sink(swagsink, prefix="/swaggerui")
+
+    specEnd = AgentSpecResource(app=adminApp, title='KERIA Interactive Web Interface API')
+    specEnd.addRoutes(happ)
+    happ.add_route("/spec.yaml", specEnd)
+    server = createHttpServer(config.httpPort, happ, config.keyPath, config.certPath, config.caFilePath)
+    if not server.reopen():
+        raise RuntimeError(f"cannot create local http server on port {config.httpPort}")
+    return http.ServerDoer(server=server)
+
+
+def setupDoers(config: KERIAServerConfig, temp=False, cf=None):
+    """
+    Sets up the HIO coroutines the KERIA agent server is composed of including three HTTP servers for a KERIA agent server:
+    1. Boot server for bootstrapping agents. Signify calls this with a signed inception event.
+    2. Admin server for administrative tasks like creating agents.
+    3. HTTP server for all other agent operations.
+
+    Parameters:
+        config (KERIAServerConfig): Configuration for the KERIA server.
+        temp (bool): Whether to use a temporary database. Default is False. Useful for testing.
+        cf (configing.Configer | None): Optional Configer instance for configuration data. Useful for testing.
+    """
+    agency = Agency(
+        name=config.name,
+        base=config.base,
+        bran=config.bran,
+        configFile=config.configFile,
+        configDir=config.configDir,
+        releaseTimeout=config.releaseTimeout,
+        curls=config.curls,
+        iurls=config.iurls,
+        durls=config.durls,
+        temp=temp,
+        cf=cf
+    )
+    bootServerDoer = createBootServerDoer(config, agency)
+    adminApp, adminServerDoer = createAdminServerDoer(config, agency)
+
+    doers = [agency, bootServerDoer, adminServerDoer]
+
+    if config.httpPort:
+        httpServerDoer = createHttpServerDoer(config, agency, adminApp)
+        doers.append(httpServerDoer)
+
+    logger.info("The Agency is loaded and waiting for requests...")
+    return doers
 
 
 class ParserDoer(doing.Doer):

--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -437,7 +437,7 @@ class Agency(doing.DoDoer):
         Should only trigger the Doist loop to exit once all agents have been removed.
         """
         super(Agency, self).exit(deeds=deeds if deeds else self.deeds)
-        if len(self.agents) == 0:
+        if len(self.agents) == 0 and self.shouldShutdown:
             raise KeyboardInterrupt("Agency shutdown complete. Exiting Agency.")
 
 class Agent(doing.DoDoer):
@@ -950,34 +950,99 @@ class Granter(doing.DoDoer):
         self.rgy = rgy
         self.agentHab = agentHab
         self.exc = exc
-        self.grants = grants
+        self.grants: decking.Deck = grants
         self.tock = tock
         super(Granter, self).__init__(always=True, tock=self.tock)
 
-    def sendAgentKEL(self, pre, recp, postman):
+    def _makeDoer(self, grant_msg: dict):
+        return GrantDoer(
+                hby=self.hby,
+                rgy=self.rgy,
+                agentHab=self.agentHab,
+                exc=self.exc,
+                granter=self,
+                grants=self.grants,
+                grant_msg=grant_msg,
+                tock=self.tock)
+
+    def postGrants(self):
+        """
+        Makes a GrantDoer per grant message to process the grant.
+        """
+        while self.grants:
+            grant_msg = self.grants.popleft()
+            self.extend([self._makeDoer(grant_msg)])
+
+    def recur(self, tyme, deeds=None):
+        """Doer lifecycle method to process grants. Continuously processes grants as they arrive."""
+        self.postGrants()
+        return super(Granter, self).recur(tyme, deeds)
+
+
+class GrantDoer(doing.Doer):
+    """
+    GrantDoer is a Doer for a single IPEX Grant operation that runs the message transmission process
+    for all KEL, TEL, and credential artifacts included in the Grant.
+
+    This GrantDoer allows for KLI-like behavior where the .postGrant can use yield expressions to
+    wait on the parent driver DoDoer to finish running the child StreamPoster DoDoer prior to
+    cleaning itself up.
+    """
+    def __init__(self, hby, rgy, agentHab, exc, granter, grants, grant_msg, tock=0.0, **kwa):
+        """
+        Accepts a list of IPEX Grant cues to process.
+
+        Parameters:
+            hby (Habery): The Agent Habery.
+            rgy (Regery): The Agent Regery.
+            agentHab (Hab): The Agent Hab.
+            exc (Exchanger): The Exchanger instance for this Agent.
+            granter (Granter): The Granter instance to use for processing grants.
+            grants (decking.Deck): Queue of grant messages to process.
+            grant_msg
+            tock (float): The time interval for processing grants.
+        """
+        if not grant_msg or not isinstance(grant_msg, dict):
+            raise ValueError(f"Grant message missing or invalid: {grant_msg}")
+        self.grant_msg = grant_msg
+        self.hby = hby
+        self.rgy = rgy
+        self.agentHab = agentHab
+        self.exc = exc
+        self.parent = granter
+        self.grants = grants
+        self.tock = tock
+        super(GrantDoer, self).__init__(tock=self.tock, **kwa)
+
+    def gatherAgentKEL(self, pre, recp, postman):
         """Send the KEL of the agent to the recipient."""
+        agent_evts = []
         for msg in self.agentHab.db.cloneDelegation(self.agentHab.kever):
             serder = serdering.SerderKERI(raw=msg)
             atc = msg[serder.size:]
-            postman.send(serder=serder, attachment=atc)
+            agent_evts.append((serder, atc))
+        return agent_evts
 
-    def sendCredArtifacts(self, recp, credSaid, postman):
+    def getCredArtifacts(self, recp, credSaid):
         """Send to the recipient the ACDC and the KELs of the issuer, holder, and any delegators."""
         creder = self.rgy.reger.creds.get(keys=(credSaid,))
-        sendArtifacts(self.hby, self.rgy.reger, postman, creder, recp)
-        self.sendChainedArtifacts(recp, creder, postman)
+        cred_artifacts = ipexing.gatherArtifacts(self.hby, self.rgy.reger, creder, recp)
+        chain_artifacts = self.getChainedArtifacts(recp, creder)
+        return cred_artifacts + chain_artifacts
 
-    def sendChainedArtifacts(self, recp, creder, postman):
+    def getChainedArtifacts(self, recp, creder):
         """
         Send to the recipient any chained ACDCs and the KELs of the issuers and holders of those
         ACDCS and the KELs of any of their delegators.
         """
+        chain_artifacts = []
         sources = self.rgy.reger.sources(self.hby.db, creder)
         for source, atc in sources:
-            sendArtifacts(self.hby, self.rgy.reger, postman, source, recp)
-            postman.send(serder=source, attachment=atc)
+            chain_artifacts.extend(ipexing.gatherArtifacts(self.hby, self.rgy.reger, source, recp))
+            chain_artifacts.append((source, atc))
+        return chain_artifacts
 
-    def postGrants(self):
+    def postGrant(self):
         """
         Presents an ACDC by sending all relevant data and cryptographic artifacts in the following order:
         - the agent KEL artifacts, including any delegation chain artifats
@@ -987,37 +1052,41 @@ class Granter(doing.DoDoer):
         - the ACDC credential itself
         This is repeated for any chained credentials except that the agent KEL is only sent once.
         """
-        if self.grants:
-            msg = self.grants.popleft()
-            said = msg['said']
-            if not self.exc.complete(said=said):
-                self.grants.append(msg)
-                return
+        msg = self.grant_msg
+        said = msg['said']
+        if not self.exc.complete(said=said):
+            self.grants.append(msg)
+            return
 
-            serder, pathed = exchanging.cloneMessage(self.hby, said)
+        serder, pathed = exchanging.cloneMessage(self.hby, said)
 
-            pre = msg["pre"]
-            rec = msg["rec"]
-            hab = self.hby.habs[pre]
-            if self.exc.lead(hab, said=said):
-                for recp in rec:
-                    postman = forwarding.StreamPoster(hby=self.hby, hab=self.agentHab, recp=recp, topic="credential")
-                    try:
-                        self.sendAgentKEL(pre, recp, postman)
-                        credSaid = serder.ked['e']['acdc']['d']
-                        self.sendCredArtifacts(recp, credSaid, postman)
-                    except kering.ValidationError:
-                        logger.info(f"unable to send to recipient={recp}")
-                    except KeyError:
-                        logger.info(f"invalid grant message={serder.ked}")
-                    else:
-                        doer = doing.DoDoer(doers=postman.deliver())
-                        self.extend([doer])
+        pre = msg["pre"]
+        rec = msg["rec"]
+        hab = self.hby.habs[pre]
+        if self.exc.lead(hab, said=said):
+            for recp in rec:
+                postman = forwarding.StreamPoster(hby=self.hby, hab=self.agentHab, recp=recp, topic="credential")
+                try:
+                    agent_evts = self.gatherAgentKEL(pre, recp, postman)
+                    credSaid = serder.ked['e']['acdc']['d']
+                    cred_artifacts = self.getCredArtifacts(recp, credSaid)
+                    artifacts = agent_evts + cred_artifacts
+                    # Queue the artifacts for later sending by postman.deliver()
+                    for serder, atc in artifacts:
+                        postman.send(serder=serder, attachment=atc)
+                except kering.ValidationError:
+                    logger.info(f"unable to send to recipient={recp}")
+                except KeyError:
+                    logger.info(f"invalid grant message={serder.ked}")
+                else:
+                    doer = doing.DoDoer(doers=postman.deliver())
+                    self.parent.extend([doer])
+        return True
 
-    def recur(self, tyme, deeds=None):
-        """Doer lifecycle method to process grants."""
-        self.postGrants()
-        return super(Granter, self).recur(tyme, deeds)
+    def recur(self, tock=0.0, **opts):
+        """Processes the IPEX Grant operation and then exits by returning True (done)."""
+        self.postGrant()
+        return True
 
 
 class Admitter(doing.Doer):

--- a/src/keria/app/aiding.py
+++ b/src/keria/app/aiding.py
@@ -834,6 +834,8 @@ class IdentifierResourceEnd:
                 title="invalid rotation",
                 description=f"required field 'rot' missing from request",
             )
+        serder = serdering.SerderKERI(sad=rot)
+        logger.info("[%s | %s...%s]: Rotation event sn=%s SAID=%s", hab.name, hab.pre[:4], hab.pre[-4:], serder.sn, serder.said)
 
         if "ba" in rot:
             for wit in rot["ba"]:
@@ -847,8 +849,6 @@ class IdentifierResourceEnd:
                 title="invalid rotation",
                 description=f"required field 'sigs' missing from request",
             )
-
-        serder = serdering.SerderKERI(sad=rot)
         sigers = [core.Siger(qb64=sig) for sig in sigs]
 
         if Algos.salty in body:
@@ -931,6 +931,8 @@ class IdentifierResourceEnd:
                 title="invalid interaction",
                 description=f"required field 'ixn' missing from request",
             )
+        serder = serdering.SerderKERI(sad=ixn)
+        logger.info("[%s | %s...%s] Interaction event sn=%s SAID=%s", hab.name, hab.pre[:4], hab.pre[-4:], serder.sn, serder.said)
 
         sigs = body.get("sigs")
         if sigs is None or len(sigs) == 0:
@@ -939,7 +941,6 @@ class IdentifierResourceEnd:
                 description=f"required field 'sigs' missing from request",
             )
 
-        serder = serdering.SerderKERI(sad=ixn)
         sigers = [core.Siger(qb64=sig) for sig in sigs]
 
         hab.interact(serder=serder, sigers=sigers)
@@ -975,6 +976,7 @@ class IdentifierResourceEnd:
             raise falcon.HTTPNotFound(title=f"No AID {name} found")
 
         code = body.get("code")
+        logger.info("[%s | %s...%s]: Resubmit event code=%s", name, hab.pre[:4], hab.pre[-4:], code)
 
         if hab.kever.wits:
             agent.submits.append(dict(alias=name, code=code))

--- a/src/keria/app/aiding.py
+++ b/src/keria/app/aiding.py
@@ -835,7 +835,7 @@ class IdentifierResourceEnd:
                 description=f"required field 'rot' missing from request",
             )
         serder = serdering.SerderKERI(sad=rot)
-        logger.info("[%s | %s...%s]: Rotation event sn=%s SAID=%s", hab.name, hab.pre[:4], hab.pre[-4:], serder.sn, serder.said)
+        logger.info("[%s | %s]: Rotation event sn=%s SAID=%s", hab.name, hab.pre, serder.sn, serder.said)
 
         if "ba" in rot:
             for wit in rot["ba"]:
@@ -932,7 +932,7 @@ class IdentifierResourceEnd:
                 description=f"required field 'ixn' missing from request",
             )
         serder = serdering.SerderKERI(sad=ixn)
-        logger.info("[%s | %s...%s] Interaction event sn=%s SAID=%s", hab.name, hab.pre[:4], hab.pre[-4:], serder.sn, serder.said)
+        logger.info("[%s | %s] Interaction event sn=%s SAID=%s", hab.name, hab.pre, serder.sn, serder.said)
 
         sigs = body.get("sigs")
         if sigs is None or len(sigs) == 0:
@@ -976,7 +976,7 @@ class IdentifierResourceEnd:
             raise falcon.HTTPNotFound(title=f"No AID {name} found")
 
         code = body.get("code")
-        logger.info("[%s | %s...%s]: Resubmit event code=%s", name, hab.pre[:4], hab.pre[-4:], code)
+        logger.info("[%s | %]: Resubmit event code=%s", name, hab.pre, code)
 
         if hab.kever.wits:
             agent.submits.append(dict(alias=name, code=code))

--- a/src/keria/app/cli/commands/start.py
+++ b/src/keria/app/cli/commands/start.py
@@ -6,7 +6,9 @@ keria.cli.keria.commands.start module
 KERIA Agent server start command line interface (CLI) command
 """
 import argparse
+import logging
 import os
+
 
 from keri import __version__
 from keri import help
@@ -77,6 +79,7 @@ parser.add_argument("--experimental-boot-username",
 
 
 logger = help.ogler.getLogger()
+
 
 def launch(args):
     agenting.runAgency(agenting.KERIAServerConfig(

--- a/src/keria/app/credentialing.py
+++ b/src/keria/app/credentialing.py
@@ -1072,7 +1072,7 @@ class Registrar:
             self.rgy.reger.tpwe.add(keys=(registry.regk, rseq.qb64), val=(hab.kever.prefixer, seqner, saider))
 
         else:
-            logger.info("[%s | %s...%s]: Waiting for TEL registry vcp event mulisig anchoring event", hab.name, hab.pre[:4], hab.pre[-4:])
+            logger.info("[%s | %s]: Waiting for TEL registry vcp event mulisig anchoring event", hab.name, hab.pre)
             self.rgy.reger.tmse.add(keys=(registry.regk, rseq.qb64, registry.regd), val=(prefixer, seqner, saider))
 
     def issue(self, regk, iserder, anc):
@@ -1097,7 +1097,7 @@ class Registrar:
             saider = coring.Saider(qb64=hab.kever.serder.said)
             registry.anchorMsg(pre=vcid, regd=iserder.said, seqner=seqner, saider=saider)
 
-            logger.info("[%s | %s...%s]: Waiting for TEL event witness receipts", hab.name, hab.pre[:4], hab.pre[-4:])
+            logger.info("[%s | %s]: Waiting for TEL event witness receipts", hab.name, hab.pre)
             self.witDoer.msgs.append(dict(pre=hab.pre, sn=seqner.sn))
             self.rgy.reger.tpwe.add(keys=(vcid, rseq.qb64), val=(hab.kever.prefixer, seqner, saider))
             return vcid, rseq.sn
@@ -1110,7 +1110,7 @@ class Registrar:
             seqner = coring.Seqner(sn=sn)
             saider = coring.Saider(qb64=said)
 
-            logger.info("[%s | %s...%s]: Waiting for TEL iss event mulisig anchoring event %s", hab.name, hab.pre[:4], hab.pre[-4:], seqner.sn)
+            logger.info("[%s | %s]: Waiting for TEL iss event mulisig anchoring event %s", hab.name, hab.pre, seqner.sn)
             self.rgy.reger.tmse.add(keys=(vcid, rseq.qb64, iserder.said), val=(prefixer, seqner, saider))
             return vcid, rseq.sn
 
@@ -1136,7 +1136,7 @@ class Registrar:
             saider = coring.Saider(qb64=hab.kever.serder.said)
             registry.anchorMsg(pre=vcid, regd=rserder.said, seqner=seqner, saider=saider)
 
-            logger.info("[%s | %s...%s]: Waiting for TEL event witness receipts", hab.name, hab.pre[:4], hab.pre[-4:])
+            logger.info("[%s | %s]: Waiting for TEL event witness receipts", hab.name, hab.pre)
             self.witDoer.msgs.append(dict(pre=hab.pre, sn=seqner.sn))
 
             self.rgy.reger.tpwe.add(keys=(vcid, rseq.qb64), val=(hab.kever.prefixer, seqner, saider))
@@ -1152,7 +1152,7 @@ class Registrar:
 
             self.counselor.start(prefixer=prefixer, seqner=seqner, saider=saider, ghab=hab)
 
-            logger.info(f"[%s | %s...%s]: Waiting for TEL rev event mulisig anchoring event %s", hab.name, hab.pre[:4], hab.pre[-4:], seqner.sn)
+            logger.info(f"[%s | %s]: Waiting for TEL rev event mulisig anchoring event %s", hab.name, hab.pre, seqner.sn)
             self.rgy.reger.tmse.add(keys=(vcid, rseq.qb64, rserder.said), val=(prefixer, seqner, saider))
             return vcid, rseq.sn
 

--- a/src/keria/app/credentialing.py
+++ b/src/keria/app/credentialing.py
@@ -9,7 +9,7 @@ import json
 from dataclasses import asdict
 
 import falcon
-from keri import kering
+from keri import kering, help
 from keri.app import signing
 from keri.app.habbing import SignifyGroupHab
 from keri.core import coring, scheming, serdering
@@ -19,6 +19,8 @@ from keri.vdr import viring
 
 from keria.core import httping, longrunning
 
+
+logger = help.ogler.getLogger()
 
 def loadEnds(app, identifierResource):
     schemaColEnd = SchemaCollectionEnd()
@@ -1022,8 +1024,22 @@ def signPaths(hab, pather, sigers):
 
 
 class Registrar:
+    """
+    Manages credential registry creation (inception), credential issuance, and credential revocation.
+    Handles witness, multisig, and dissemination escrows for registry and credential operations.
+    """
 
     def __init__(self, agentHab, hby, rgy, counselor, witDoer, witPub, verifier):
+        """
+        Parameters:
+            hby (habbing.Habery): Habery in which the Agent lives
+            agentHab (habbing.Habitat): Agent
+            rgy (Regery): registry for the agent
+            counselor (Counselor): counselor for the agent
+            witDoer (WitnessReceiptor): retrieves receipts registry and credential events from witnesses
+            witPub (WitnessPublisher): publishes registry and credential events to witnesses
+            verifier (Verifier): Verifies TEL events
+        """
         self.hby = hby
         self.agentHab = agentHab
         self.rgy = rgy
@@ -1056,7 +1072,7 @@ class Registrar:
             self.rgy.reger.tpwe.add(keys=(registry.regk, rseq.qb64), val=(hab.kever.prefixer, seqner, saider))
 
         else:
-            print("Waiting for TEL registry vcp event mulisig anchoring event")
+            logger.info("[%s | %s...%s]: Waiting for TEL registry vcp event mulisig anchoring event", hab.name, hab.pre[:4], hab.pre[-4:])
             self.rgy.reger.tmse.add(keys=(registry.regk, rseq.qb64, registry.regd), val=(prefixer, seqner, saider))
 
     def issue(self, regk, iserder, anc):
@@ -1081,7 +1097,7 @@ class Registrar:
             saider = coring.Saider(qb64=hab.kever.serder.said)
             registry.anchorMsg(pre=vcid, regd=iserder.said, seqner=seqner, saider=saider)
 
-            print("Waiting for TEL event witness receipts")
+            logger.info("[%s | %s...%s]: Waiting for TEL event witness receipts", hab.name, hab.pre[:4], hab.pre[-4:])
             self.witDoer.msgs.append(dict(pre=hab.pre, sn=seqner.sn))
             self.rgy.reger.tpwe.add(keys=(vcid, rseq.qb64), val=(hab.kever.prefixer, seqner, saider))
             return vcid, rseq.sn
@@ -1094,7 +1110,7 @@ class Registrar:
             seqner = coring.Seqner(sn=sn)
             saider = coring.Saider(qb64=said)
 
-            print(f"Waiting for TEL iss event mulisig anchoring event {seqner.sn}")
+            logger.info("[%s | %s...%s]: Waiting for TEL iss event mulisig anchoring event %s", hab.name, hab.pre[:4], hab.pre[-4:], seqner.sn)
             self.rgy.reger.tmse.add(keys=(vcid, rseq.qb64, iserder.said), val=(prefixer, seqner, saider))
             return vcid, rseq.sn
 
@@ -1120,7 +1136,7 @@ class Registrar:
             saider = coring.Saider(qb64=hab.kever.serder.said)
             registry.anchorMsg(pre=vcid, regd=rserder.said, seqner=seqner, saider=saider)
 
-            print("Waiting for TEL event witness receipts")
+            logger.info("[%s | %s...%s]: Waiting for TEL event witness receipts", hab.name, hab.pre[:4], hab.pre[-4:])
             self.witDoer.msgs.append(dict(pre=hab.pre, sn=seqner.sn))
 
             self.rgy.reger.tpwe.add(keys=(vcid, rseq.qb64), val=(hab.kever.prefixer, seqner, saider))
@@ -1136,7 +1152,7 @@ class Registrar:
 
             self.counselor.start(prefixer=prefixer, seqner=seqner, saider=saider, ghab=hab)
 
-            print(f"Waiting for TEL rev event mulisig anchoring event {seqner.sn}")
+            logger.info(f"[%s | %s...%s]: Waiting for TEL rev event mulisig anchoring event %s", hab.name, hab.pre[:4], hab.pre[-4:], seqner.sn)
             self.rgy.reger.tmse.add(keys=(vcid, rseq.qb64, rserder.said), val=(prefixer, seqner, saider))
             return vcid, rseq.sn
 
@@ -1233,7 +1249,7 @@ class Registrar:
             for msg in self.rgy.reger.clonePreIter(pre=regk, fn=rseq.sn):
                 tevt.extend(msg)
 
-            print(f"Sending TEL events to witnesses")
+            logger.info(f"Sending TEL events to witnesses")
             # Fire and forget the TEL event to the witnesses.  Consumers will have to query
             # to determine when the Witnesses have received the TEL events.
             self.witPub.msgs.append(dict(pre=prefixer.qb64, msg=tevt))

--- a/src/keria/app/credentialing.py
+++ b/src/keria/app/credentialing.py
@@ -1257,8 +1257,24 @@ class Registrar:
 
 
 class Credentialer:
+    """
+    Places credentials into the credential missing signature escrow, handles the credential signature
+    escrow, and has utility functions to validate a credential against its schema and to know
+    if a credential's anchoring event is completely signed.
+    """
 
     def __init__(self, agentHab, hby, rgy, registrar, verifier, notifier):
+        """
+        Initialize the Credentialer
+
+        Parameters:
+            agentHab (Hab): Hab of the agent performing credential operations
+            hby (Habery): Habery in which the Agent lives
+            rgy (Regery): Container for local registries and their associated Tevers
+            registrar (Registrar): Creation and escrowing for registries and credential issuance/revocation
+            verifier (Verifier): Verifies and escrows TEL events.
+            notifier (Notifier): Handles notifying controllers of significant events
+        """
         self.agentHab = agentHab
         self.hby = hby
         self.rgy = rgy
@@ -1268,13 +1284,15 @@ class Credentialer:
 
     def validate(self, creder):
         """
+        Validates a credential against its schema.
 
         Args:
             creder (Creder): creder object representing the credential to validate
 
         Returns:
-            bool: true if credential is valid against a known schema
-
+            bool: True if credential is valid against a known schema
+        Raises:
+            kering.ConfigurationError: if the credential schema is not found or validation fails
         """
         schema = creder.sad['s']
         scraw = self.verifier.resolver.resolve(schema)

--- a/src/keria/app/credentialing.py
+++ b/src/keria/app/credentialing.py
@@ -662,7 +662,9 @@ class CredentialCollectionEnd:
             rep.text = e.args[0]
             return
 
-        regk = iserder.ked['ri']
+        regk = iserder.ked['ri'] if 'ri' in iserder.ked else iserder.ked['ii'] if 'ii' in iserder.ked else None
+        if regk is None:
+            raise falcon.HTTPBadRequest(description="credential issuance request missing registry (ri) or (ii) field")
         if regk not in agent.rgy.tevers:
             raise falcon.HTTPNotFound(description=f"issue against invalid registry SAID {regk}")
 

--- a/src/keria/app/delegating.py
+++ b/src/keria/app/delegating.py
@@ -1,7 +1,7 @@
 import falcon
 
 from hio.base import doing
-from keri import kering
+from keri import kering, help
 from keri.app import forwarding, agenting, habbing
 from keri.core import coring, serdering
 from keri.db import dbing
@@ -9,6 +9,8 @@ from keri.db import dbing
 from keria.core import httping, longrunning
 
 DELEGATION_ROUTE = "/identifiers/{name}/delegation"
+
+logger = help.ogler.getLogger()
 
 def loadEnds(app, identifierResource):
     gatorEnd = DelegatorEnd(identifierResource)
@@ -29,11 +31,8 @@ class Anchorer(doing.DoDoer):
         gather all receipts and send them to all other witnesses
 
         Parameters:
-            hab (Hab): Habitat of the identifier to populate witnesses
-            msg (bytes): is the message to send to all witnesses.
-                 Defaults to sending the latest KEL event if msg is None
-            scheme (str): Scheme to favor if available
-
+            hby (Habery): Habery of the agent to populate witnesses
+            proxy (Hab): Agent Hab to use as a messaging proxy to send messages to the delegator on behalf of SignifyHab instances as SignifyHabs cannot sign messages in a KERIA Agent.
         """
         self.hby = hby
         self.postman = forwarding.Poster(hby=hby)
@@ -132,7 +131,7 @@ class Anchorer(doing.DoDoer):
                 self.hby.db.setAes(dgkey, couple)  # authorizer event seal (delegator/issuer)
 
                 # Move to escrow waiting for witness receipts
-                print(f"Delegation approval received,  {serder.pre} confirmed")
+                logger.info("[%s...%s]: Delegation approval received, %s confirmed", pre[:4], pre[-4:], serder.pre)
                 self.hby.db.cdel.put(keys=(pre, coring.Seqner(sn=serder.sn).qb64), val=coring.Saider(qb64=serder.said))
                 self.hby.db.dune.rem(keys=(pre, said))
 
@@ -160,7 +159,7 @@ class Anchorer(doing.DoDoer):
                             witnessed = True
                     if not witnessed:
                         continue
-                print(f"Witness receipts complete, waiting for delegation approval.")
+                logger.info("[%s...%s]: Witness receipts complete, waiting for delegation approval for %s", pre[:4], pre[-4:], serder.pre)
                 if isinstance(hab, habbing.GroupHab):
                     phab = hab.mhab
                 elif self.proxy is not None:
@@ -168,7 +167,7 @@ class Anchorer(doing.DoDoer):
                 elif hab.kever.sn > 0:
                     phab = hab
                 else:
-                    raise kering.ValidationError("no proxy to send messages for delegation")
+                    raise kering.ValidationError("No proxy to send messages for delegation for AID [%s...%s]", pre[:4], pre[-4:])
 
                 evt = hab.db.cloneEvtMsg(pre=serder.pre, fn=0, dig=serder.said)
 
@@ -180,7 +179,7 @@ class Anchorer(doing.DoDoer):
                 self.hby.db.dune.pin(keys=(srdr.pre, srdr.said), val=srdr)
                 
 class DelegatorEnd:
-    """ Resource class for for handling delegator events"""
+    """ Resource class for handling delegator events"""
     
     def __init__(self, identifierResource) -> None:
         """
@@ -192,7 +191,7 @@ class DelegatorEnd:
         self.identifierResource = identifierResource
 
     def on_post(self, req, rep, name):
-        """ Identifier delegator enpoint POST to create the ixn anchor and approve the delegation
+        """ Identifier delegator endpoint POST to create the ixn anchor and approve the delegation
 
         Parameters:
             req (Request): falcon.Request HTTP request object

--- a/src/keria/app/delegating.py
+++ b/src/keria/app/delegating.py
@@ -131,7 +131,7 @@ class Anchorer(doing.DoDoer):
                 self.hby.db.setAes(dgkey, couple)  # authorizer event seal (delegator/issuer)
 
                 # Move to escrow waiting for witness receipts
-                logger.info("[%s...%s]: Delegation approval received, %s confirmed", pre[:4], pre[-4:], serder.pre)
+                logger.info("[%s]: Delegation approval received, %s confirmed", pre, serder.pre)
                 self.hby.db.cdel.put(keys=(pre, coring.Seqner(sn=serder.sn).qb64), val=coring.Saider(qb64=serder.said))
                 self.hby.db.dune.rem(keys=(pre, said))
 
@@ -159,7 +159,7 @@ class Anchorer(doing.DoDoer):
                             witnessed = True
                     if not witnessed:
                         continue
-                logger.info("[%s...%s]: Witness receipts complete, waiting for delegation approval for %s", pre[:4], pre[-4:], serder.pre)
+                logger.info("[%s]: Witness receipts complete, waiting for delegation approval for %s", pre, serder.pre)
                 if isinstance(hab, habbing.GroupHab):
                     phab = hab.mhab
                 elif self.proxy is not None:
@@ -167,7 +167,7 @@ class Anchorer(doing.DoDoer):
                 elif hab.kever.sn > 0:
                     phab = hab
                 else:
-                    raise kering.ValidationError("No proxy to send messages for delegation for AID [%s...%s]", pre[:4], pre[-4:])
+                    raise kering.ValidationError("No proxy to send messages for delegation for AID %s]", pre)
 
                 evt = hab.db.cloneEvtMsg(pre=serder.pre, fn=0, dig=serder.said)
 

--- a/src/keria/app/delegating.py
+++ b/src/keria/app/delegating.py
@@ -85,7 +85,7 @@ class Anchorer(doing.DoDoer):
 
         return True
 
-    def escrowDo(self, tymth, tock=1.0):
+    def escrowDo(self, tymth, tock=1.0, temp=False, **opts):
         """ Process escrows of group multisig identifiers waiting to be compeleted.
 
         Steps involve:

--- a/src/keria/app/grouping.py
+++ b/src/keria/app/grouping.py
@@ -59,7 +59,7 @@ class MultisigRequestCollectionEnd:
         sigs = httping.getRequiredParam(body, "sigs")
         atc = httping.getRequiredParam(body, "atc")
 
-        logger.info("[%s | %s...%s]: Posting EXN on Route %s event %s", name, hab.pre[:4], hab.pre[-4:], ked["r"], ked["d"])
+        logger.info("[%s | %s]: Posting EXN on Route %s event %s", name, hab.pre, ked["r"], ked["d"])
         logger.debug("EXN: %s", json.dumps(body))
 
         # create sigers from the edge signatures so we can messagize the whole thing
@@ -81,7 +81,7 @@ class MultisigRequestCollectionEnd:
         if hab.mhab.pre in smids:
             smids.remove(hab.mhab.pre)
 
-        logger.info("[%s | %s...%s]: new exchange message %s", name, hab.pre[:4], hab.pre[-4:], json.dumps(dict(said=serder.said, pre=hab.pre, rec=smids, topic='multisig')))
+        logger.info("[%s | %s]: new exchange message %s", name, hab.pre, json.dumps(dict(said=serder.said, pre=hab.pre, rec=smids, topic='multisig')))
         agent.exchanges.append(dict(said=serder.said, pre=hab.pre, rec=smids, topic='multisig'))
 
         rep.status = falcon.HTTP_200

--- a/src/keria/app/grouping.py
+++ b/src/keria/app/grouping.py
@@ -52,11 +52,15 @@ class MultisigRequestCollectionEnd:
         if not isinstance(hab, habbing.SignifyGroupHab):
             raise falcon.HTTPBadRequest(description=f"hab for alias or prefix {name} is not a multisig")
 
+
         # grab all of the required parameters
         ked = httping.getRequiredParam(body, "exn")
         serder = serdering.SerderKERI(sad=ked)
         sigs = httping.getRequiredParam(body, "sigs")
         atc = httping.getRequiredParam(body, "atc")
+
+        logger.info("[%s | %s...%s]: Posting EXN on Route %s event %s", name, hab.pre[:4], hab.pre[-4:], ked["r"], ked["d"])
+        logger.debug("EXN: %s", json.dumps(body))
 
         # create sigers from the edge signatures so we can messagize the whole thing
         sigers = [core.Siger(qb64=sig) for sig in sigs]
@@ -77,6 +81,7 @@ class MultisigRequestCollectionEnd:
         if hab.mhab.pre in smids:
             smids.remove(hab.mhab.pre)
 
+        logger.info("[%s | %s...%s]: new exchange message %s", name, hab.pre[:4], hab.pre[-4:], json.dumps(dict(said=serder.said, pre=hab.pre, rec=smids, topic='multisig')))
         agent.exchanges.append(dict(said=serder.said, pre=hab.pre, rec=smids, topic='multisig'))
 
         rep.status = falcon.HTTP_200

--- a/src/keria/app/ipexing.py
+++ b/src/keria/app/ipexing.py
@@ -11,6 +11,7 @@ import falcon
 from keri import core
 from keri.app import habbing
 from keri.core import coring, eventing, serdering
+from keri.vdr import credentialing
 from keri.peer import exchanging
 
 from keria.core import httping, longrunning
@@ -623,3 +624,65 @@ class IpexAgreeCollectionEnd:
         agent.exchanges.append(dict(said=serder.said, pre=hab.pre, rec=[agreeRec], topic="credential"))
 
         return agent.monitor.submit(serder.said, longrunning.OpTypes.exchange, metadata=dict(said=serder.said))
+
+def gatherArtifacts(hby: habbing.Habery, reger: credentialing.Reger, creder: serdering.SerderACDC, recp: str):
+    """
+    Gathers a list from the local database of all dependent credential artifacts needed by the
+    recipient to fully verify an ACDC including all KEL and TEL events for the issuer and issuee and
+    any of their (delegators.
+
+    Parameters:
+        hby: Habery to read KELs from
+        reger: Registry to read registries and ACDCs from
+        creder: The credential to send
+        recp: recipient
+
+    Returns:
+        A list of (Serder, attachment) tuples to send
+    """
+    messages = []
+    issr = creder.issuer
+    isse = creder.attrib["i"] if "i" in creder.attrib else None
+    regk = creder.regi
+
+    # Get issuer delegation parent KELs
+    ikever = hby.db.kevers[issr]
+    for msg in hby.db.cloneDelegation(ikever):
+        serder = serdering.SerderKERI(raw=msg)
+        atc = msg[serder.size:]
+        messages.append((serder, atc))
+
+    # get issuer KEL
+    for msg in hby.db.clonePreIter(pre=issr):
+        serder = serdering.SerderKERI(raw=msg)
+        atc = msg[serder.size:]
+        messages.append((serder, atc))
+
+    # If sending to recipient that is no the issuee then
+    # Get issuee KEL and delegation parent KELs
+    if isse != recp:
+        ikever = hby.db.kevers[isse]
+        for msg in hby.db.cloneDelegation(ikever):
+            serder = serdering.SerderKERI(raw=msg)
+            atc = msg[serder.size:]
+            messages.append((serder, atc))
+
+        for msg in hby.db.clonePreIter(pre=isse):
+            serder = serdering.SerderKERI(raw=msg)
+            atc = msg[serder.size:]
+            messages.append((serder, atc))
+
+    # Get registry TEL
+    if regk is not None:
+        for msg in reger.clonePreIter(pre=regk):
+            serder = serdering.SerderKERI(raw=msg)
+            atc = msg[serder.size:]
+            messages.append((serder, atc))
+
+    # get ACDC iss or bis event
+    for msg in reger.clonePreIter(pre=creder.said):
+        serder = serdering.SerderKERI(raw=msg)
+        atc = msg[serder.size:]
+        messages.append((serder, atc))
+
+    return messages

--- a/src/keria/app/logs.py
+++ b/src/keria/app/logs.py
@@ -1,0 +1,20 @@
+import logging
+
+
+class TruncatedFormatter(logging.Formatter):
+    """Formats log records with shorter module and function names and a right justified line number for readability."""
+    def __init__(self, fmt=None, datefmt=None, style='%'):
+        super().__init__(fmt, datefmt, style)
+
+    def format(self, record):
+        # Truncate module and funcName to first 'chars' characters
+        mod_chars = 12 # number of spaces to truncate to
+        fn_chars = 16 # number of spaces to truncate to
+        record.module = (record.module[:mod_chars] + ' ' * mod_chars)[:mod_chars]
+        record.funcName = (record.funcName[:fn_chars] + ' ' * fn_chars)[:fn_chars]
+        record.lineno = str(record.lineno).rjust(5)  # Ensure line number is right-aligned
+        try:
+            return super().format(record)
+        except Exception as e:
+            logging.error(f'Error formatting log record: {e}')
+            raise e

--- a/src/keria/app/serving.py
+++ b/src/keria/app/serving.py
@@ -41,7 +41,7 @@ class GracefulShutdownDoer(doing.Doer):
         logger.info("Stopping Agency")
         self.agency.shouldShutdown = True  # Set the shutdown flag in the Agency
 
-    def enter(self):
+    def enter(self, temp=False):
         """
         Sets up signal handlers.
         Lifecycle method called once when the Doist running this Doer enters the context for this Doer.
@@ -51,7 +51,7 @@ class GracefulShutdownDoer(doing.Doer):
         signal.signal(signal.SIGINT, self.handle_sigint)
         logger.info("Registered signal handlers for SIGTERM")
 
-    def recur(self, tyme=None, tock=0.0):
+    def recur(self, tyme=None, tock=0.0, **opts):
         """Generator coroutine checking once per tock for shutdown flag"""
         # Checks once per tock if the shutdown flag has been set and if so initiates the shutdown process
         while not self.shutdown_received:

--- a/src/keria/app/serving.py
+++ b/src/keria/app/serving.py
@@ -7,18 +7,20 @@ logger = help.ogler.getLogger()
 
 class GracefulShutdownDoer(doing.Doer):
     """
-    Shuts all Agency agents down before exiting the Doist loop, performing a graceful shutdown.
-    Sets up signal handler in the Doer.enter lifecycle method and exits the Doist scheduler loop in Doer.exit
+    Shuts all Agency agents down before throwing a KeyboardInterrup to cause the Doist loop to exit,
+    performing a graceful shutdown.
+    Sets up signal handler in the Doer.enter lifecycle method.
     Checks for the shutdown flag being set in the Doer.recur lifecycle method.
     """
-    def __init__(self, doist, agency, **kwa):
+    def __init__(self, agency, **kwa):
         """
+        Sets up the GracefulShutdownDoer with the Agency. Eventually the Agency should manage itself
+        with its own exit function that shuts down all agents gracefully.
+
         Parameters:
-            doist (Doist): The Doist running this Doer
             agency (Agency): The Agency containing Agent instances to be gracefully shut down
             kwa (dict): Additional keyword arguments for Doer initialization
         """
-        self.doist: Doist = doist
         self.agency = agency
         self.shutdown_received = False
 
@@ -27,6 +29,11 @@ class GracefulShutdownDoer(doing.Doer):
     def handle_sigterm(self, signum, frame):
         """Handler function for SIGTERM"""
         logger.info(f"Received SIGTERM, initiating graceful shutdown.")
+        self.shutdown_received = True
+
+    def handle_sigint(self, signum, frame):
+        """Handler function for SIGINT"""
+        logger.info(f"Received SIGINT, initiating graceful shutdown.")
         self.shutdown_received = True
 
     def shutdown_agents(self, agents):
@@ -42,6 +49,7 @@ class GracefulShutdownDoer(doing.Doer):
         """
         # Register signal handler
         signal.signal(signal.SIGTERM, self.handle_sigterm)
+        signal.signal(signal.SIGINT, self.handle_sigint)
         logger.info("Registered signal handlers for SIGTERM")
 
     def recur(self, tock=0.0):
@@ -50,16 +58,17 @@ class GracefulShutdownDoer(doing.Doer):
         while not self.shutdown_received:
             yield tock # will iterate forever in here until shutdown flag set
 
-        # Once shutdown_flag is set, exit the Doist loop
-        self.shutdown_agents(list(self.agency.agents.keys()))
+        logger.info("Shutdown flag received, initiating graceful shutdown of agents")
 
+        # Once shutdown_flag is set, exit the Doist loop by triggering .exit() after finishing this recur.
         return True # Returns a "done" status
-        # Causes the Doist scheduler to call .exit() lifecycle method below, killing the doist loop
+        # Causes the Doist scheduler to call .exit() lifecycle method below, killing the Doist loop with the KeyboardInterrupt
 
     def exit(self):
         """
         Exits the Doist loop.
         Lifecycle method called once when the Doist running this Doer exits the context for this Doer.
         """
-        logger.info(f"Shutting down main Doist loop")
-        self.doist.exit()
+        logger.info("Shutting down all agents in the Agency")
+        self.shutdown_agents(list(self.agency.agents.keys()))
+        raise KeyboardInterrupt("Graceful shutdown finished, causing Doist loop to exit")

--- a/src/keria/core/httping.py
+++ b/src/keria/core/httping.py
@@ -4,9 +4,16 @@ KERIA
 keria.core.httping module
 
 """
+import io
+import logging
 
 import falcon
 from falcon.http_status import HTTPStatus
+from hio.core import tcp, http
+
+from keria import ogler, log_name
+
+logger = ogler.getLogger(log_name)
 
 class HandleCORS(object):
     def process_request(self, req, resp):
@@ -60,3 +67,74 @@ def parseRangeHeader(header, name, start=0, end=9):
         return start, end
 
 
+# noinspection PyMethodMayBeStatic
+class RequestLoggerMiddleware:
+    """Simple request logger Falcon middleware."""
+
+    def process_request(self, req: falcon.Request, resp: falcon.Response):
+        """Log incoming requests."""
+        logger.info('Request received : %s %s', req.method, req.url)
+        logger.debug('Request headers : %s', req.headers)
+        if req.content_length and logger.isEnabledFor(logging.DEBUG):
+            # Read and re-set the stream to allow further processing
+            body = req.stream.read()
+            decoded_body = body.decode('utf-8') if body else '<empty>'
+            logger.debug('Request body    : %s', decoded_body)
+            req.env['wsgi.input'] = io.BytesIO(body)  # Reset the stream for further processing
+            req.env['CONTENT_LENGTH'] = str(len(body))  # match WSGI env content length to body length
+        else:
+            logger.debug('Request body    : No body')
+
+    def process_response(self, req: falcon.Request, resp: falcon.Response, resource, req_succeeded):
+        """Log outgoing responses."""
+        logger.info(f'Response status  : %s on %s %s', resp.status, req.method, req.url)
+        logger.debug(f'Response headers: %s', resp.headers)
+
+
+def keri_headers():
+    return [
+        'cesr-attachment',
+        'cesr-date',
+        'content-type',
+        'signature',
+        'signature-input',
+        'signify-resource',
+        'signify-timestamp'
+    ]
+
+
+def corsMiddleware():
+    return falcon.CORSMiddleware(
+        allow_origins='*',
+        allow_credentials='*',
+        expose_headers=keri_headers()
+    )
+
+
+def falconApp():
+    return falcon.App(middleware=[corsMiddleware(), RequestLoggerMiddleware()])
+
+
+def createHttpServer(port, app, keypath=None, certpath=None, cafilepath=None):
+    """
+    Create an HTTP or HTTPS server depending on whether TLS key material is present
+
+    Parameters:
+        port (int)         : port to listen on for all HTTP(s) server instances
+        app (falcon.App)   : application instance to pass to the http.Server instance
+        keypath (string)   : the file path to the TLS private key
+        certpath (string)  : the file path to the TLS signed certificate (public key)
+        cafilepath (string): the file path to the TLS CA certificate chain file
+    Returns:
+        hio.core.http.Server
+    """
+    if keypath is not None and certpath is not None and cafilepath is not None:
+        servant = tcp.ServerTls(certify=False,
+                                keypath=keypath,
+                                certpath=certpath,
+                                cafilepath=cafilepath,
+                                port=port)
+        server = http.Server(port=port, app=app, servant=servant)
+    else:
+        server = http.Server(port=port, app=app)
+    return server

--- a/src/keria/core/keeping.py
+++ b/src/keria/core/keeping.py
@@ -133,6 +133,10 @@ class RemoteKeeper(dbing.LMDBer):
 
 
 class RemoteManager:
+    """
+    Local key index manager representing the key index state of the remotely managed keys for the
+    associated remote Signify controller.
+    """
     def __init__(self, hby, rb: RemoteKeeper = None):
         self.hby = hby
         self.rb = rb if rb is not None else RemoteKeeper(name=hby.name,

--- a/src/keria/db/basing.py
+++ b/src/keria/db/basing.py
@@ -28,7 +28,7 @@ class IndexRecord:
 
 class AgencyBaser(dbing.LMDBer):
     """
-    Agency database for tracking Agent tenants in this KERIA instance.
+    Agency database for tracking Agent tenants and their managed identifiers in this KERIA instance.
 
     """
 
@@ -48,7 +48,7 @@ class AgencyBaser(dbing.LMDBer):
                 default name='main'
             temp is boolean, assign to .temp
                 True then open in temporary directory, clear on close
-                Othewise then open persistent directory, do not clear on close
+                Otherwise then open persistent directory, do not clear on close
                 default temp=False
             headDirPath is optional str head directory pathname for main database
                 If not provided use default .HeadDirpath
@@ -58,17 +58,26 @@ class AgencyBaser(dbing.LMDBer):
             reopen is boolean, IF True then database will be reopened by this init
                 default reopen=True
 
+        Attributes:
+            .agnt values are Prefixer of Agent AID
+                keyed by controller AID (caid).
+                Maps Controller AIDs to their Signify Agent AID (agent.pre).
+            .ctrl values are Prefixer of Controller AID (caid)
+                keyed by Agent AID.
+                Maps Agent AIDs to their Signify Controller AID (caid).
+            .aids values are Prefixer of Controller AID (caid)
+                keyed by managed AID.
+                Maps managed AIDs to their Signify Controller AID (caid).
+
         Notes:
+            dupsort=True for sub DB means allow unique (key,pair) duplicates at a key.
+            Duplicate means that is more than one value at a key but not a redundant
+            copies a (key,value) pair per key. In other words the pair (key,value)
+            must be unique both key and value in combination.
+            Attempting to put the same (key,value) pair a second time does
+            not add another copy.
 
-        dupsort=True for sub DB means allow unique (key,pair) duplicates at a key.
-        Duplicate means that is more than one value at a key but not a redundant
-        copies a (key,value) pair per key. In other words the pair (key,value)
-        must be unique both key and value in combination.
-        Attempting to put the same (key,value) pair a second time does
-        not add another copy.
-
-        Duplicates are inserted in lexocographic order by value, insertion order.
-
+            Duplicates are inserted in lexicographic order by value, insertion order.
         """
         if perm is None:
             perm = self.Perm  # defaults to restricted permissions for non temp

--- a/src/keria/peer/exchanging.py
+++ b/src/keria/peer/exchanging.py
@@ -10,8 +10,10 @@ import falcon
 from keri import core
 from keri.core import coring, eventing, serdering
 from keri.peer import exchanging
-
+from keri.help import ogler
 from keria.core import httping
+
+logger = ogler.getLogger()
 
 
 def loadEnds(app):
@@ -104,6 +106,9 @@ class ExchangeCollectionEnd:
         serder = serdering.SerderKERI(sad=ked)
         sigers = [core.Siger(qb64=sig) for sig in sigs]
 
+        logger.info("[%s | %s...%s] ExchangeCollectionEnd: route %s received exn %s being sent to [%s]",
+                    name, hab.pre[:4], hab.pre[-4:], serder.ked['r'], serder.said, ", ".join(rec))
+
         # Now create the stream to send, need the signer seal
         kever = hab.kever
         seal = eventing.SealEvent(i=hab.pre, s="{:x}".format(kever.lastEst.s), d=kever.lastEst.d)
@@ -118,6 +123,8 @@ class ExchangeCollectionEnd:
 
         msg = dict(said=serder.said, pre=hab.pre, rec=rec, topic=topic)
 
+        logger.info("[%s | %s...%s] ExchangeCollectionEnd: appending %s",
+                    name, hab.pre[:4], hab.pre[-4:], json.dumps(msg))
         agent.exchanges.append(msg)
 
         rep.status = falcon.HTTP_202

--- a/src/keria/peer/exchanging.py
+++ b/src/keria/peer/exchanging.py
@@ -106,7 +106,7 @@ class ExchangeCollectionEnd:
         serder = serdering.SerderKERI(sad=ked)
         sigers = [core.Siger(qb64=sig) for sig in sigs]
 
-        logger.info("[%s | %s] ExchangeCollectionEnd: route %s received exn %s being sent to [%s]",
+        logger.info("[%s | %s]: route %s received exn %s being sent to [%s]",
                     name, hab.pre, serder.ked['r'], serder.said, ", ".join(rec))
 
         # Now create the stream to send, need the signer seal
@@ -123,7 +123,7 @@ class ExchangeCollectionEnd:
 
         msg = dict(said=serder.said, pre=hab.pre, rec=rec, topic=topic)
 
-        logger.info("[%s | %s] ExchangeCollectionEnd: appending %s",
+        logger.info("[%s | %s]: appending %s",
                     name, hab.pre, json.dumps(msg))
         agent.exchanges.append(msg)
 

--- a/src/keria/peer/exchanging.py
+++ b/src/keria/peer/exchanging.py
@@ -106,8 +106,8 @@ class ExchangeCollectionEnd:
         serder = serdering.SerderKERI(sad=ked)
         sigers = [core.Siger(qb64=sig) for sig in sigs]
 
-        logger.info("[%s | %s...%s] ExchangeCollectionEnd: route %s received exn %s being sent to [%s]",
-                    name, hab.pre[:4], hab.pre[-4:], serder.ked['r'], serder.said, ", ".join(rec))
+        logger.info("[%s | %s] ExchangeCollectionEnd: route %s received exn %s being sent to [%s]",
+                    name, hab.pre, serder.ked['r'], serder.said, ", ".join(rec))
 
         # Now create the stream to send, need the signer seal
         kever = hab.kever
@@ -123,8 +123,8 @@ class ExchangeCollectionEnd:
 
         msg = dict(said=serder.said, pre=hab.pre, rec=rec, topic=topic)
 
-        logger.info("[%s | %s...%s] ExchangeCollectionEnd: appending %s",
-                    name, hab.pre[:4], hab.pre[-4:], json.dumps(msg))
+        logger.info("[%s | %s] ExchangeCollectionEnd: appending %s",
+                    name, hab.pre, json.dumps(msg))
         agent.exchanges.append(msg)
 
         rep.status = falcon.HTTP_202

--- a/src/keria/testing/testing_helper.py
+++ b/src/keria/testing/testing_helper.py
@@ -7,6 +7,7 @@ import os
 import pathlib
 import shutil
 from contextlib import contextmanager
+from typing import Tuple, List
 
 import falcon
 from falcon import testing
@@ -17,7 +18,7 @@ from keri.app import keeping, habbing, configing, signing
 from keri.core import coring, eventing, parsing, routing, scheming, serdering
 from keri.core.coring import MtrDex
 from keri.core.eventing import SealEvent
-from keri.core.signing import Salter
+from keri.core.signing import Salter, Signer
 from keri.help import helping
 from keri.kering import TraitCodex
 from keri.vc import proving
@@ -324,12 +325,22 @@ class Helpers:
 
     @staticmethod
     def controller(bran=b'0123456789abcdefghijk'):
+        """
+        Creates a Signify Controller using a Signify stem in the key seed using a single signer.
+        Returns:
+            (SerderKERI, List[Siger]): The inception event serder and list of signatures
+        """
         serder, signers = Helpers.incept(bran=bran, stem="signify:controller", pidx=0)
         sigers = [signers[0].sign(ser=serder.raw, index=0)]
         return serder, sigers
 
     @staticmethod
-    def incept(bran, stem, pidx, count=1, sith="1", wits=None, toad="0", delpre=None):
+    def incept(bran, stem, pidx, count=1, sith="1", wits=None, toad="0", delpre=None) -> Tuple[serdering.SerderKERI, List[Signer]]:
+        """
+        Perform a regular inception event with the given parameters.
+        Returns:
+            (SerderKERI, List[Signer]): The inception event serder and list of signers
+        """
         if wits is None:
             wits = []
 
@@ -552,7 +563,13 @@ class Helpers:
     @staticmethod
     @contextmanager
     def openKeria(salter=None, cf=None, temp=True):
+        """
+        Creates a Signify Controller and it's associated Agent, Agent Habery, containing Agency,
+        Falcon HTTP App, and Falcon test client. The Agency has a single Agent.
 
+        Returns:
+            (Agency, Agent, falcon.App, TestClient): The agency, agent, Falcon HTTP app, and Falcon HTTP test client
+        """
         serder, sigers = Helpers.controller()
         assert serder.pre == Helpers.controllerAID
 
@@ -563,11 +580,11 @@ class Helpers:
         if cf is None:
             cf = configing.Configer(name="keria", headDirPath=SCRIPTS_DIR, reopen=True, clear=False)
 
+        agency = agenting.Agency(name="agency", bran=None, temp=True)
         with habbing.openHby(name="keria", salt=salter.qb64, temp=temp, cf=cf) as hby:
             ims = eventing.messagize(serder, sigers=sigers)
             parsing.Parser(kvy=hby.kvy).parseOne(ims=ims)
 
-            agency = agenting.Agency(name="agency", bran=None, temp=True)
             agentHab = hby.makeHab(serder.pre, ns="agent", transferable=True, delpre=serder.pre)
 
             rgy = credentialing.Regery(hby=hby, name=agentHab.name, base=hby.base, temp=True)

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -223,7 +223,7 @@ def test_agency():
         agency = agenting.Agency(name="agency", base="", bran=None, temp=True, configFile="keria",
                                  configDir=SCRIPTS_DIR)
         assert agency.cf is not None
-        assert agency.cf.path.endswith("scripts/keri/cf/keria.json") is True
+        assert agency.cf.path.endswith("keri/cf/keria.json") is True
 
         tock = 0.03125
         limit = 1.0

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -37,22 +37,26 @@ from keria.testing.testing_helper import SCRIPTS_DIR
 
 
 def test_setup_no_http():
-    doers = agenting.setupDoers(agenting.KERIAServerConfig(
+    config = agenting.KERIAServerConfig(
         name="test",
         adminPort=1234,
         bootPort=5678,
         httpPort=None,
-    ))
+    )
+    agency = agenting.createAgency(config, temp=True, cf=None)
+    doers = agenting.setupDoers(agency, config)
     assert len(doers) == 3
     assert isinstance(doers[0], agenting.Agency) is True
 
 def test_setup():
-    doers = agenting.setupDoers(agenting.KERIAServerConfig(
+    config = agenting.KERIAServerConfig(
         name="test",
         adminPort=1234,
         bootPort=5678,
         httpPort=9999,
-    ))
+    )
+    agency = agenting.createAgency(config, temp=True, cf=None)
+    doers = agenting.setupDoers(agency, config)
     assert len(doers) == 4
 
 def wait_for_server(port, timeout=10):

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -32,7 +32,7 @@ from keri.help import nowIso8601
 from keri.vdr import credentialing
 
 from keria.app import agenting, aiding
-from keria.core import longrunning
+from keria.core import longrunning, httping
 from keria.testing.testing_helper import SCRIPTS_DIR
 
 
@@ -746,14 +746,14 @@ class MockHttpServer:
 def test_createHttpServer(monkeypatch):
     port = 5632
     app = falcon.App()
-    server = agenting.createHttpServer(port, app)
+    server = httping.createHttpServer(port, app)
     assert isinstance(server, http.Server)
 
     monkeypatch.setattr(hio.core.tcp, 'ServerTls', MockServerTls)
     monkeypatch.setattr(hio.core.http, 'Server', MockHttpServer)
 
-    server = agenting.createHttpServer(port, app, keypath='keypath', certpath='certpath',
-                                          cafilepath='cafilepath')
+    server = httping.createHttpServer(port, app, keypath='keypath', certpath='certpath',
+                                                 cafilepath='cafilepath')
 
     assert isinstance(server, MockHttpServer)
     assert isinstance(server.servant, MockServerTls)

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -117,9 +117,9 @@ def test_graceful_shutdown_doer():
         doers = [agency, shutdownDoer]
         doist.enter(doers=doers)
 
-        caid = "ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose"
+        caid = "ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtBose"
         agent = agency.create(caid, salt=salter.qb64)
-        assert agent.pre == "EIAEKYpTygdBtFHBrHKWeh0aYCdx0ZJqZtzQLFnaDB2b"
+        assert agent.pre == "EHgwniP6WZdB0PWNsf0FmFfFpJCp-pSDKiHJ1QqMCCjX"
         assert len(agency.agents) == 1, "Agent not created as expected."
 
         assert shutdownDoer.shutdown_received is False
@@ -217,7 +217,7 @@ def test_load_tocks_config(helpers):
 
 
 def test_agency():
-    salt = b'0123456789abcdef'
+    salt = b'0123456789aaaaaa'
     salter = core.Salter(raw=salt)
     cf = configing.Configer(name="keria", headDirPath=SCRIPTS_DIR, temp=True, reopen=True, clear=False)
 
@@ -236,14 +236,14 @@ def test_agency():
 
         caid = "ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose"
         agent = agency.create(caid, salt=salter.qb64)
-        assert agent.pre == "EIAEKYpTygdBtFHBrHKWeh0aYCdx0ZJqZtzQLFnaDB2b"
+        assert agent.pre == "EBtONOpwylm2krDPNyvfN8F1dlbAxpGcKBcY7WRzs3aq"
 
         badcaid = "E987eerAdhmvrjDeam2eAO2SR5niCgnjAJXJHtJoe"
         agent = agency.get(badcaid)
         assert agent is None
 
         agent = agency.get(caid)
-        assert agent.pre == "EIAEKYpTygdBtFHBrHKWeh0aYCdx0ZJqZtzQLFnaDB2b"
+        assert agent.pre == "EBtONOpwylm2krDPNyvfN8F1dlbAxpGcKBcY7WRzs3aq"
 
         agency.incept(caid, hab.pre)
 
@@ -251,7 +251,7 @@ def test_agency():
         assert agent is None
 
         agent = agency.lookup(hab.pre)
-        assert agent.pre == "EIAEKYpTygdBtFHBrHKWeh0aYCdx0ZJqZtzQLFnaDB2b"
+        assert agent.pre == "EBtONOpwylm2krDPNyvfN8F1dlbAxpGcKBcY7WRzs3aq"
 
         # Create non-temp Agency and test reload of agent from disk
         base = "keria-temp"
@@ -278,7 +278,7 @@ def test_agency():
 
         caid = "ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose"
         agent = agency.create(caid, salt=salter.qb64)
-        assert agent.pre == "EEXekkGu9IAzav6pZVJhkLnjtjM5v3AcyA-pdKUcaGei"
+        assert agent.pre == "EBtONOpwylm2krDPNyvfN8F1dlbAxpGcKBcY7WRzs3aq"
 
         # Rcreate the agency to see if agent is reloaded from disk
         agency = agenting.Agency(name="agency", base=base, bran=None, configFile="keria",
@@ -286,7 +286,7 @@ def test_agency():
         doist.enter(doers=[agency])
 
         agent = agency.get(caid)
-        assert agent.pre == "EEXekkGu9IAzav6pZVJhkLnjtjM5v3AcyA-pdKUcaGei"
+        assert agent.pre == "EBtONOpwylm2krDPNyvfN8F1dlbAxpGcKBcY7WRzs3aq"
 
         # Clean up afterwards
         if os.path.exists(f'/usr/local/var/keri/db/{base}'):
@@ -303,7 +303,7 @@ def test_agency():
         assert len(agent.doers) == 0
 
 def test_agency_without_config_file():
-    salt = b'0123456789abcdef'
+    salt = b'0123456789bbbbbb'
     salter = core.Salter(raw=salt)
     cf = configing.Configer(name="keria", headDirPath=SCRIPTS_DIR, temp=True, reopen=True, clear=False)
 
@@ -317,12 +317,12 @@ def test_agency_without_config_file():
         doist.extend(doers=[agency])
 
         # Ensure we can still create agent
-        caid = "ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose"
+        caid = "ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtCose"
         agent = agency.create(caid, salt=salter.qb64)
-        assert agent.pre == "EIAEKYpTygdBtFHBrHKWeh0aYCdx0ZJqZtzQLFnaDB2b"
+        assert agent.pre == "EIaGV6pWVbL9wlltrNYPefQvnRUlb58ZmWvlDoX_BM_2"
 
 def test_agency_with_urls_from_arguments():
-    salt = b'0123456789abcdef'
+    salt = b'0123456789dddddd'
     salter = core.Salter(raw=salt)
     cf = configing.Configer(name="keria", headDirPath=SCRIPTS_DIR, temp=True, reopen=True, clear=False)
 
@@ -339,9 +339,9 @@ def test_agency_with_urls_from_arguments():
         doist.extend(doers=[agency])
 
         # Ensure we can still create agent
-        caid = "ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose"
+        caid = "ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtRose"
         agent = agency.create(caid, salt=salter.qb64)
-        assert agent.pre == "EIAEKYpTygdBtFHBrHKWeh0aYCdx0ZJqZtzQLFnaDB2b"
+        assert agent.pre == "EC1Df_cBKDQ-NsTzFX-WwTozEniLl19WqWMdwE3WoZkQ"
 
         assert agent.hby.cf is not None
         assert agent.hby.cf.get()[f"agent-{caid}"]["curls"] == curls
@@ -383,9 +383,9 @@ def test_unprotected_boot_ends(helpers):
 
 def test_protected_boot_ends(helpers):
     credentials = [
-        dict(bran=b'0123456789abcdefghija', username="user", password="secret"), 
-        dict(bran=b'0123456789abcdefghijb', username="admin", password="secret with spaces"),
-        dict(bran=b'0123456789abcdefghijc', username="admin", password="secret : with colon")
+        dict(bran=b'0123456789aaaaaaghija', username="user", password="secret"),
+        dict(bran=b'0123456789bbbbbbghijb', username="admin", password="secret with spaces"),
+        dict(bran=b'0123456789ccccccghijc', username="admin", password="secret : with colon")
     ]
 
     for credential in credentials:
@@ -487,8 +487,8 @@ def test_witnesser(helpers):
 
 
 def test_keystate_ends(helpers):
-    caid = "ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose"
-    salt = b'0123456789abcdef'
+    caid = "ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtDose"
+    salt = b'0123456789cccccc'
     salter = core.Salter(raw=salt)
     cf = configing.Configer(name="keria", headDirPath=SCRIPTS_DIR, temp=True, reopen=True, clear=False)
 
@@ -514,13 +514,13 @@ def test_keystate_ends(helpers):
 
         state = states[0]
         assert state['i'] == hab.pre
-        assert state['d'] == "EIaGMMWJFPmtXznY1IIiKDIrg-vIyge6mBl2QV8dDjI3"
+        assert state['d'] == "EJ9ZaKf0e89CsaowWPjEpJ_oZc-OYWgRNTYULjQcGOwp"
         assert state['et'] == 'icp'
-        assert state['k'] == ['DGmIfLmgErg4zFHfPwaDckLNxsLqc5iS_P0QbLjbWR0I']
-        assert state['n'] == ['EJhRr10e5p7LVB6JwLDIcgqsISktnfe5m60O_I2zZO6N']
+        assert state['k'] == ['DFbG433Fct2JBjNzRFT_lnk_-7Ymnl5Ig6RRsEE9fCS2']
+        assert state['n'] == ['EIgTsJ65kMPQGWXM5FB81Hcgyfz9iv4gWmZVP5a_RIOF']
         assert state['ee'] == {'ba': [],
                                'br': [],
-                               'd': 'EIaGMMWJFPmtXznY1IIiKDIrg-vIyge6mBl2QV8dDjI3',
+                               'd': 'EJ9ZaKf0e89CsaowWPjEpJ_oZc-OYWgRNTYULjQcGOwp',
                                's': '0'}
 
 

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -109,7 +109,7 @@ def test_graceful_shutdown_doer():
         tock = 0.03125
         limit = 1.0
         doist = doing.Doist(limit=limit, tock=tock, real=True)
-        shutdownDoer = agenting.GracefulShutdownDoer(doist=doist, agency=agency)
+        shutdownDoer = agenting.GracefulShutdownDoer(agency=agency)
         doers = [agency, shutdownDoer]
         doist.enter(doers=doers)
 
@@ -127,7 +127,11 @@ def test_graceful_shutdown_doer():
         # See test_shutdown_signals test above for an example of sending signals.
         shutdownDoer.handle_sigterm(signal.SIGTERM, None)
 
-        doist.do(doers=doers)
+        try:  # need to catch the KeyboardInterrupt so that Pytest does not stop executing after this test.
+            doist.do(doers=doers)
+        except KeyboardInterrupt as ex:
+            # This simulates the Doist loop being interrupted by the shutdown signal
+            assert str(ex) == "Graceful shutdown finished, causing Doist loop to exit"
         assert  shutdownDoer.shutdown_received is True
 
         # shutdownDoer.shutdown_agents(agency.agents)

--- a/tests/app/test_ipexing.py
+++ b/tests/app/test_ipexing.py
@@ -8,6 +8,8 @@ Testing credentialing endpoint in the Mark II Agent
 import json
 
 import falcon
+import keri
+import pytest
 from falcon import testing
 from hio.base import doing
 from hio.help import decking
@@ -1465,14 +1467,17 @@ def test_granter(helpers):
 
         deeds = doist.enter(doers=[granter])
 
-        said = "EHwjDEsub6XT19ISLft1m1xMNvVXnSfH0IsDGllox4Y8"
+        exn, _ = exchanging.exchange(route="/ipex/grant", payload=dict(), sender=agent.agentHab.pre)
+        said = exn.sad['d']
         msg = dict(said=said)
+        agent.hby.db.exns.pin(keys=(said,), val=exn)
 
         grants.append(msg)
 
-        doist.recur(deeds=deeds)
+        with pytest.raises(keri.kering.MissingSignatureError):
+            doist.recur(deeds=deeds)
 
-        assert len(grants) == 1
+        assert len(grants) == 0, "Granter should have removed the grant from the queue"
 
 
 def test_ipex_apply(helpers, mockHelpingNowIso8601):

--- a/tests/core/test_authing.py
+++ b/tests/core/test_authing.py
@@ -21,7 +21,7 @@ from keria.core import authing
 
 
 def test_authenticater(mockHelpingNowUTC):
-    salt = b'0123456789abcdef'
+    salt = b'1111456789abcdef'
     salter = core.Salter(raw=salt)
 
     with habbing.openHab(name="caid", salt=salt, temp=True) as (controllerHby, controller):
@@ -54,12 +54,12 @@ def test_authenticater(mockHelpingNowUTC):
         assert dict(headers) == {'Connection': 'close',
                                  'Content-Length': '256',
                                  'Content-Type': 'application/json',
-                                 'Signature': 'indexed="?0";signify="0BA9SX7Jyn66ZdCPOb0WqDEn1UC49GeSPypjVgeMrt6VLWKjEw'
-                                              '9ij7Ndur7Wcrru_5eQNbSiNaiP4NQYWht5srEL"',
-                                 'Signature-Input': 'signify=("signify-resource" "@method" "@path" '
-                                                    '"signify-timestamp");created=1609459200;keyid="EJPEPKslRHD_fkug3zm'
-                                                    'oyjQ90DazQAYWI8JIrV2QXyhg";alg="ed25519"',
-                                 'Signify-Resource': 'EJPEPKslRHD_fkug3zmoyjQ90DazQAYWI8JIrV2QXyhg',
+                                 'Signature': 'indexed="?0";signify="0BDBVr5ape8f9nV60ThhWOKvu5HKXQc5798Sz95FIoqXQ9vvL8HoYsLRp5aN86MIXr0GqH37SowsmTP-k9UhYSkN"',
+                                 'Signature-Input': 'signify=("signify-resource" "@method" "@path" "signify-timestamp");'
+                                                    'created=1609459200;'
+                                                    'keyid="EPwUOBk9QkxPM20JBaf_pFXPytSjTUoyxbx95uZJE1Hq";'
+                                                    'alg="ed25519"',
+                                 'Signify-Resource': 'EPwUOBk9QkxPM20JBaf_pFXPytSjTUoyxbx95uZJE1Hq',
                                  'Signify-Timestamp': '2022-09-24T00:05:48.196795+00:00'}
 
         req = testing.create_req(method="POST", path="/boot", headers=dict(headers))
@@ -87,12 +87,13 @@ def test_authenticater(mockHelpingNowUTC):
         assert dict(headers) == {'Connection': 'close',
                                  'Content-Length': '256',
                                  'Content-Type': 'application/json',
-                                 'Signature': 'indexed="?0";signify="0BBMtZXbDnueGAiNiNxHpZKrtBwdA7fPVz-dHiXOeSjkSu45C7'
-                                              'EwCGgpAhnKX8Agz_yjJjAehyyz9Zc7ivtd_MkL"',
-                                 'Signature-Input': 'signify=("signify-resource" "@method" "@path" '
-                                                    '"signify-timestamp");created=1609459200;keyid="EDqDrGuzned0HOKFTLq'
-                                                    'd7m7O7WGE5zYIOHrlCq4EnWxy";alg="ed25519"',
-                                 'Signify-Resource': 'EDqDrGuzned0HOKFTLqd7m7O7WGE5zYIOHrlCq4EnWxy',
+                                 'Signature': 'indexed="?0";'
+                                              'signify="0BC9St6MbQGrlDz_s7Yvuw_yIxy_kJJgMbWMFfOpSGB1lo08vNUrlm5SATNUCxQ7fZEJ7n2Tio0b9-Oa8qYDOxwA"',
+                                 'Signature-Input': 'signify=("signify-resource" "@method" "@path" "signify-timestamp");'
+                                                    'created=1609459200;'
+                                                    'keyid="ELNtprDCa-IuYLaBwx1PoZEYFG3dPb7QqFdwzoYycYE9";'
+                                                    'alg="ed25519"',
+                                 'Signify-Resource': 'ELNtprDCa-IuYLaBwx1PoZEYFG3dPb7QqFdwzoYycYE9',
                                  'Signify-Timestamp': '2022-09-24T00:05:48.196795+00:00'}
 
 
@@ -205,7 +206,7 @@ def test_signature_validation(mockHelpingNowUTC):
     assert rep.complete is True
     assert rep.status == falcon.HTTP_401
 
-    salt = b'0123456789abcdef'
+    salt = b'0000456789abcdef'
     salter = core.Salter(raw=salt)
     with habbing.openHab(name="caid", salt=salt, temp=True) as (controllerHby, controller):
 
@@ -223,10 +224,10 @@ def test_signature_validation(mockHelpingNowUTC):
 
         vc = authing.SignatureValidationComponent(agency=agency, authn=authn)
         vc.process_response(req, rep, None, True)
-        assert rep.headers == {'signature': 'indexed="?0";signify="0BA6rPilZo3Fv3e3lIRxoZncbrn0RpPdDcQqxN3Jolsvl4WBkpXl'
-                                            'rmFJ5NmLbQNikChIzUiDn1XEMU-ecCTnSmYD"',
-                               'signature-input': 'signify=("signify-resource" "@method" "@path" '
-                                                  '"signify-timestamp");created=1609459200;keyid="EDqDrGuzned0HOKFTLqd7'
-                                                  'm7O7WGE5zYIOHrlCq4EnWxy";alg="ed25519"',
-                               'signify-resource': 'EDqDrGuzned0HOKFTLqd7m7O7WGE5zYIOHrlCq4EnWxy',
+        assert rep.headers == {'signature': 'indexed="?0";signify="0BCr_xdIyaON0Ct2lsY7Qv7yibVPAqLkzoxjDf-moBuwjyhKrxdD6k5sJb-H2svUqNbiZW1oQMW4kUCVxDB4BckF"',
+                               'signature-input': 'signify=("signify-resource" "@method" "@path" "signify-timestamp");'
+                                                  'created=1609459200;'
+                                                  'keyid="EIcBTeg_rMjz3uH7b5Rz5IanGn0EtyHBRGF-CAzotWW3";'
+                                                  'alg="ed25519"',
+                               'signify-resource': 'EIcBTeg_rMjz3uH7b5Rz5IanGn0EtyHBRGF-CAzotWW3',
                                'signify-timestamp': '2021-01-01T00:00:00.000000+00:00'}


### PR DESCRIPTION
This PR adds a few things I used when fixing the first time IPEX Grant failure bug including:
- Allowing a `Configer` to be passed in to the Agency and thereby the Agent since the Agent just copies the Agency's config when created.
- Respecting the `temp=True` argument. Useful for consistent testing.
- Moved the `TruncatedFormatter` to the `keria.app.logs` module since it belongs in a topic-specific module instead of in the Agenting module.
- Clarified the Agency and Agent configuration process with a bit of refactoring.
- Added HTTP Request Logging
- Moved some HTTP-related functions from `agenting` to the `httping` module for clarity.